### PR TITLE
Feature/temperature type naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
 # Temperature Monitoring Starter Solution
-Run with docker: `docker compose up --build`

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -115,7 +115,7 @@
           "refId": "A"
         }
       ],
-      "title": "Ambient temperature",
+      "title": "Temperature",
       "type": "timeseries"
     },
     {

--- a/temperature_dc/code/adc/BCRoboticsADC.py
+++ b/temperature_dc/code/adc/BCRoboticsADC.py
@@ -1,13 +1,14 @@
 # ----------------------------------------------------------------------
 #
-#    Power Monitoring (Basic solution) -- This digital solution measures,
-#    reports and records both AC power and current consumed by an electrical 
-#    equipment, so that its energy consumption can be understood and 
-#    taken action upon. This version comes with one current transformer 
-#    clamp of 20A that is buckled up to the electric line the equipment 
-#    is connected to. The solution provides a Grafana dashboard that 
-#    displays current and power consumption, and an InfluxDB database 
-#    to store timestamp, current and power. 
+#    Temperature Monitoring (Basic solution) -- This digital solution enables, measures,
+#    reports and records different  types of temperatures (contact, air, radiated)
+#    so that the temperature conditions surrounding a process can be understood and 
+#    taken action upon. Suppored sensors include 
+#    k-type thermocouples, RTDs, air samplers, and NIR-based sensors.
+#    The solution provides a Grafana dashboard that 
+#    displays the temperature timeseries, set threshold value, and a state timeline showing 
+#    the chnage in temperature. An InfluxDB database is used to store timestamp, temperature, 
+#    threshold and status. 
 #
 #    Copyright (C) 2022  Shoestring and University of Cambridge
 #

--- a/temperature_dc/code/adc/GravityADC.py
+++ b/temperature_dc/code/adc/GravityADC.py
@@ -1,13 +1,14 @@
 # ----------------------------------------------------------------------
 #
-#    Power Monitoring (Basic solution) -- This digital solution measures,
-#    reports and records both AC power and current consumed by an electrical 
-#    equipment, so that its energy consumption can be understood and 
-#    taken action upon. This version comes with one current transformer 
-#    clamp of 20A that is buckled up to the electric line the equipment 
-#    is connected to. The solution provides a Grafana dashboard that 
-#    displays current and power consumption, and an InfluxDB database 
-#    to store timestamp, current and power. 
+#    Temperature Monitoring (Basic solution) -- This digital solution enables, measures,
+#    reports and records different  types of temperatures (contact, air, radiated)
+#    so that the temperature conditions surrounding a process can be understood and 
+#    taken action upon. Suppored sensors include 
+#    k-type thermocouples, RTDs, air samplers, and NIR-based sensors.
+#    The solution provides a Grafana dashboard that 
+#    displays the temperature timeseries, set threshold value, and a state timeline showing 
+#    the chnage in temperature. An InfluxDB database is used to store timestamp, temperature, 
+#    threshold and status. 
 #
 #    Copyright (C) 2022  Shoestring and University of Cambridge
 #

--- a/temperature_dc/code/adc/GroveADC.py
+++ b/temperature_dc/code/adc/GroveADC.py
@@ -1,13 +1,14 @@
 # ----------------------------------------------------------------------
 #
-#    Power Monitoring (Basic solution) -- This digital solution measures,
-#    reports and records both AC power and current consumed by an electrical 
-#    equipment, so that its energy consumption can be understood and 
-#    taken action upon. This version comes with one current transformer 
-#    clamp of 20A that is buckled up to the electric line the equipment 
-#    is connected to. The solution provides a Grafana dashboard that 
-#    displays current and power consumption, and an InfluxDB database 
-#    to store timestamp, current and power. 
+#    Temperature Monitoring (Basic solution) -- This digital solution enables, measures,
+#    reports and records different  types of temperatures (contact, air, radiated)
+#    so that the temperature conditions surrounding a process can be understood and 
+#    taken action upon. Suppored sensors include 
+#    k-type thermocouples, RTDs, air samplers, and NIR-based sensors.
+#    The solution provides a Grafana dashboard that 
+#    displays the temperature timeseries, set threshold value, and a state timeline showing 
+#    the chnage in temperature. An InfluxDB database is used to store timestamp, temperature, 
+#    threshold and status. 
 #
 #    Copyright (C) 2022  Shoestring and University of Cambridge
 #

--- a/temperature_dc/code/adc/MAX31865.py
+++ b/temperature_dc/code/adc/MAX31865.py
@@ -1,0 +1,164 @@
+# toby_max31865.py
+# Toby Harris 2024 @ IfM Engage
+# Usage: see test section at end of file
+
+import spidev
+from math import sqrt
+import time
+
+class max31865:
+
+	# Register definitions
+	REG_CONFIG_READ = 0x00
+	REG_CONFIG_WRITE = 0x80
+	REG_RTD_READING = 0x01
+
+
+	def __init__(self, R_Ref=438, spi_bus=0, spi_cs=0, spi_speed=7629, spi_clock_polarity=1, spi_clock_phase=1):
+
+		self.R_Ref = R_Ref	# ADC full scale. Ideally around 4*R_0dC. Our board's resistor is marked 431 => 430 ohms, but measuring it suggests 438.
+
+		self.spi = spidev.SpiDev()
+		self.spi.open(spi_bus, spi_cs)
+		self.spi.max_speed_hz = spi_speed
+		self.spi.mode = (spi_clock_polarity << 1 | spi_clock_phase)	# 0b11 or else...
+
+
+	def __call__(self):
+		return self.calculate_resistance(self._read_adc())
+
+
+	def _read_regs(self, first_reg_addr,  nregs=8):
+		"""Read nregs consecutive registers, starting from first_reg_addr"""
+
+		"""
+		A note on the registers of the MAX31865:
+		00h = Config
+		01h = RTD MSBs
+		02h = RTD LSBs
+		03h = High Fault Threshold MSB
+		04h = High Fault Threshold LSB
+		05h = Low Fault Threshold MSB
+		06h = Low Fault Threshold LSB
+		07h = Fault Status
+		"""
+
+		resp = self.spi.xfer2([first_reg_addr] + [0]*nregs)[1:] # Ignore first byte as it was while the command was being clocked in
+		return resp
+
+
+	def _write_reg(self, reg_addr, data):
+		self.spi.writebytes([reg_addr, data])			# Can be temperamental and cause seg faults, but behaving today.
+#		self.spi.xfer2([reg_addr, data])			# More reliable, even when discarding the response.
+
+
+	def _bytes_to_15bit(self, MSBs_byte, LSBs_byte):
+		"""extract a 15bit int from two bytes, MSB justified"""
+		return ((MSBs_byte <<8 | LSBs_byte) >> 1)
+
+
+	def _read_adc(self):
+		"""clock data out of the adc and return as int"""
+		reading_bytes = self._read_regs(self.REG_RTD_READING, 2)
+		ADC_Code = self._bytes_to_15bit(reading_bytes[0], reading_bytes[1])
+		return ADC_Code
+
+
+
+	def set_config(self, VBias=0, continous=0, oneshot=0, threewire=0, faultdetect=0, faultclear=0, filter50Hz=0):
+		"""
+		Overwrite the config register:
+		---------------
+		bit 7: Vbias (1=ON, 0=OFF). Needs to be on in either mode to get new readings.
+		bit 6: Conversion Mode (1=Auto/Continous, 0=OFF/Manual)
+		bit 5: 1-shot (1=1-shot on, auto cleared)
+		bit 4: 3-wire select (1=3 wire config, 0=2 or 4 wire config)
+		bits 3-2: fault detection cycle (0=none, otherwise see data sheet)
+		bit 1: fault status clear (1=Clear any fault, auto cleared)
+		bit 0: 50/60 Hz filter select (1=50Hz, 0=60Hz)
+		"""
+
+		new_config_byte = (VBias << 7 | continous << 6 | oneshot << 5 | threewire << 4 | faultdetect << 2 | faultclear << 1 | filter50Hz)
+		self._write_reg(self.REG_CONFIG_WRITE, new_config_byte)
+
+
+	def oneshot(self):
+		"""Request a single reading without otherwise changing the config."""
+		current_config = self._read_regs(self.REG_CONFIG_READ, 1)[0]
+		new_config = (current_config  | 0b00100000)
+		self._write_reg(self.REG_CONFIG_WRITE, new_config)
+
+
+	def calculate_resistance(self, adc_code, adc_fullscale=32768):
+		"""Calculate the resistance of the RTD, with R_Ref as full scale """
+		R_RTD = self.R_Ref * adc_code / adc_fullscale
+		return R_RTD
+
+
+class PT_RTD:
+
+	def __init__(self, R_0dC, a=3.9083e-3, b=-5.775e-7, c_pos=0, c_neg=-4.18301e-12):
+
+		self.R_0dC = R_0dC	# The RTD resistance at 0 degrees C. Common standards are 100 and 1000.
+
+		# A great model of PT-RTD resistance vs temperature is the Callendar-Van Dusen equation:
+		# R_RTD = R_0dC * (1 + a*T + b*T**2 + c*(T-100)*T**3)
+		# Standard constants (IEC7751/SAMA) as default
+
+		self.a = a
+		self.b = b
+		self.c_pos = c_pos	# For temperatures above 0 degrees C
+		self.c_neg = c_neg	# For temperatures below 0 degrees C
+
+
+	def __call__(self, resistance):
+		"""shorthand for most common usage"""
+		return self.calculate_temperature_quadratic(resistance)
+
+
+	def calculate_temperature_linear(self, resistance):
+
+		# Linear approximation:
+		T_C_linear = ((resistance / self.R_0dC) - 1) / self.a
+		return T_C_linear
+
+	def calculate_temperature_quadratic(self, resistance):
+
+		# Quadratic approximation (unfortunately the constants do not follow convention):
+		# R_RTD / R_0dC = 1 + aT + bt^2
+		# T = (-a +- sqrt(a^2-4b(1-R_RTD/R_0dC))) / 2b
+		T_C_quadratic = ( -self.a + sqrt((self.a**2)-4*self.b*(1-(resistance/self.R_0dC))) )/(2*self.b)
+		return T_C_quadratic
+
+#	def calculate_temperature_quartic(self, resistance):
+		# Full Callendar-Van Dussen, improves on quad below 0dC.
+		# tbd
+
+
+# test
+if __name__ == '__main__':
+
+	MyMax = max31865()
+	MyMax.set_config(VBias=1, filter50Hz=1)
+	time.sleep(0.5)
+	MyRTD = PT_RTD(100)
+
+	# test in oneshot mode
+	print("oneshot mode:")
+	for i in range(5):
+		MyMax.oneshot()
+		time.sleep(0.1) # after activating oneshot measurement, conversion takes about 60ms until DATA_READY falls low (=ready). 100ms is safe margin.
+		print(MyRTD(MyMax()))
+		time.sleep(1)
+	time.sleep(1)
+
+	# test in continous mode
+	print("continous mode:")
+	MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
+	time.sleep(0.5)
+
+	for i in range(5):
+		print(MyRTD(MyMax()))
+		time.sleep(1)
+
+	MyMax.spi.close()

--- a/temperature_dc/code/adc/MAX31865.py
+++ b/temperature_dc/code/adc/MAX31865.py
@@ -1,5 +1,31 @@
-# toby_max31865.py
-# Toby Harris 2024 @ IfM Engage
+# ----------------------------------------------------------------------
+#
+#    Temperature Monitoring (Basic solution) -- This digital solution enables, measures,
+#    reports and records different  types of temperatures (contact, air, radiated)
+#    so that the temperature conditions surrounding a process can be understood and 
+#    taken action upon. Suppored sensors include 
+#    k-type thermocouples, RTDs, air samplers, and NIR-based sensors.
+#    The solution provides a Grafana dashboard that 
+#    displays the temperature timeseries, set threshold value, and a state timeline showing 
+#    the chnage in temperature. An InfluxDB database is used to store timestamp, temperature, 
+#    threshold and status. 
+#
+#    Copyright (C) 2022  Shoestring and University of Cambridge
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, version 3 of the License.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see https://www.gnu.org/licenses/.
+#
+# ----------------------------------------------------------------------
+
 # Usage: see test section at end of file
 
 import spidev

--- a/temperature_dc/code/adc/SequentMicrosystemsRTDHAT.py
+++ b/temperature_dc/code/adc/SequentMicrosystemsRTDHAT.py
@@ -1,0 +1,115 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2020 Sequent Microsystems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+#import smbus  # The only Shoestring edit to the sequent microsystems code: 
+import smbus2 as smbus # swapping out the above line for this one.
+import struct
+
+# bus = smbus.SMBus(1)    # 0 = /dev/i2c-0 (port I2C0), 1 = /dev/i2c-1 (port I2C1)
+
+DEVICE_ADDRESS = 0x40  # 7 bit address (will be left shifted to add the read write bit)
+
+RTD_TEMPERATURE_ADD = 0
+RTD_RESISTANCE_ADD = 59
+
+
+def get(stack, channel):
+    if stack < 0 or stack > 7:
+        raise ValueError('Invalid stack level')
+    if channel < 1 or channel > 8:
+        raise ValueError('Invalid channel number')
+    val = (-273.15)
+    bus = smbus.SMBus(1)
+    try:
+        buff = bus.read_i2c_block_data(DEVICE_ADDRESS + stack, RTD_TEMPERATURE_ADD + (4 * (channel - 1)), 4)
+        val = struct.unpack('f', bytearray(buff))
+    except Exception as e:
+        bus.close()
+        raise ValueError('Fail to communicate with the RTD card with message: \"' + str(e) + '\"')
+    bus.close()
+    return val[0]
+
+
+def getRes(stack, channel):
+    if stack < 0 or stack > 7:
+        raise ValueError('Invalid stack level')
+    if channel < 1 or channel > 8:
+        raise ValueError('Invalid channel number')
+    val = (-273.15)
+    bus = smbus.SMBus(1)
+    try:
+        buff = bus.read_i2c_block_data(DEVICE_ADDRESS + stack, RTD_RESISTANCE_ADD + (4 * (channel - 1)), 4)
+        val = struct.unpack('f', bytearray(buff))
+    except Exception as e:
+        bus.close()
+        raise ValueError('Fail to communicate with the RTD card with message: \"' + str(e) + '\"')
+    bus.close()
+    return val[0]
+
+
+def get_poly5(stack: int, channel: int) -> float:
+    """
+    Convert RTD reading to Temperature, using 5th order polynomial fit of Temperature as a function of Resistance.
+    This fit provides much improved accuracy through the temperature range of [-200C, 660C], particularly near the high
+    and low ranges, compared to the default linear fitting function baked into the Sequent RTD Data Acquisition
+    Stackable Card for Raspberry Pi.  The coefficients for this fit were developed in a project documented
+    in https://github.com/ewjax/max31865
+
+        temp_C = (c5 * res^5) + (c4 * res^4) + (c3 * res^3) + (c2 * res^2) + (c1 * res) + c0
+
+    :param stack: 0-7, which hat to read
+    :param channel: 1-8, which RTD to read on indicated hat
+    :return: temperature, in celcius
+    """
+
+    # coeffs for 5th order fit
+    c5 = -2.10678E-11
+    c4 = 2.27311E-08
+    c3 = -8.20888E-06
+    c2 = 2.38589E-03
+    c1 = 2.24745E+00
+    c0 = -2.42522E+02
+
+    # get RTD resistance
+    res = getRes(stack, channel)
+
+    # do the math
+    #   Rearrange a bit to make it friendlier (less expensive) to calculate
+    #   temp_C = res ( res ( res ( res ( res * c5 + c4) + c3) + c2) + c1) + c0
+    temp_C = res * c5 + c4
+
+    temp_C *= res
+    temp_C += c3
+
+    temp_C *= res
+    temp_C += c2
+
+    temp_C *= res
+    temp_C += c1
+
+    temp_C *= res
+    temp_C += c0
+
+    return temp_C

--- a/temperature_dc/code/adc/testADC.py
+++ b/temperature_dc/code/adc/testADC.py
@@ -1,13 +1,14 @@
 # ----------------------------------------------------------------------
 #
-#    Power Monitoring (Basic solution) -- This digital solution measures,
-#    reports and records both AC power and current consumed by an electrical 
-#    equipment, so that its energy consumption can be understood and 
-#    taken action upon. This version comes with one current transformer 
-#    clamp of 20A that is buckled up to the electric line the equipment 
-#    is connected to. The solution provides a Grafana dashboard that 
-#    displays current and power consumption, and an InfluxDB database 
-#    to store timestamp, current and power. 
+#    Temperature Monitoring (Basic solution) -- This digital solution enables, measures,
+#    reports and records different  types of temperatures (contact, air, radiated)
+#    so that the temperature conditions surrounding a process can be understood and 
+#    taken action upon. Suppored sensors include 
+#    k-type thermocouples, RTDs, air samplers, and NIR-based sensors.
+#    The solution provides a Grafana dashboard that 
+#    displays the temperature timeseries, set threshold value, and a state timeline showing 
+#    the chnage in temperature. An InfluxDB database is used to store timestamp, temperature, 
+#    threshold and status. 
 #
 #    Copyright (C) 2022  Shoestring and University of Cambridge
 #

--- a/temperature_dc/code/calculate.py
+++ b/temperature_dc/code/calculate.py
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------------
 #
 #    Temperature Monitoring (Basic solution) -- This digital solution enables, measures,
-#    reports and records different  types of temperatures (ambient, process, equipment)
+#    reports and records different  types of temperatures (contact, air, radiated)
 #    so that the temperature conditions surrounding a process can be understood and 
-#    taken action upon. This version can work for 4 types of temperature sensors (now)
-#    which include k-type, RTD, ambient (AHT20), and NIR-based sensors. 
+#    taken action upon. Suppored sensors include 
+#    k-type thermocouples, RTDs, air samplers, and NIR-based sensors.
 #    The solution provides a Grafana dashboard that 
 #    displays the temperature timeseries, set threshold value, and a state timeline showing 
 #    the chnage in temperature. An InfluxDB database is used to store timestamp, temperature, 

--- a/temperature_dc/code/main.py
+++ b/temperature_dc/code/main.py
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------------
 #
 #    Temperature Monitoring (Basic solution) -- This digital solution enables, measures,
-#    reports and records different  types of temperatures (ambient, process, equipment)
+#    reports and records different  types of temperatures (contact, air, radiated)
 #    so that the temperature conditions surrounding a process can be understood and 
-#    taken action upon. This version can work for 4 types of temperature sensors (now)
-#    which include k-type, RTD, ambient (AHT20), and NIR-based sensors. 
+#    taken action upon. Suppored sensors include 
+#    k-type thermocouples, RTDs, air samplers, and NIR-based sensors.
 #    The solution provides a Grafana dashboard that 
 #    displays the temperature timeseries, set threshold value, and a state timeline showing 
 #    the chnage in temperature. An InfluxDB database is used to store timestamp, temperature, 

--- a/temperature_dc/code/measure.py
+++ b/temperature_dc/code/measure.py
@@ -118,6 +118,8 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
             sensor = sen.aht20()
         elif self.config['sensing']['adc'] == 'PT100_arduino':
             sensor = sen.PT100_arduino()
+        elif self.config['sensing']['adc'] == 'PT100_raspi':
+            sensor = sen.PT100_raspi()
 
         else:
             raise Exception(f'ADC "{self.config["sensing"]["adc"]}" not recognised/supported')

--- a/temperature_dc/code/measure.py
+++ b/temperature_dc/code/measure.py
@@ -120,6 +120,8 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
             sensor = sen.PT100_arduino()
         elif self.config['sensing']['adc'] == 'PT100_raspi':
             sensor = sen.PT100_raspi()
+        elif self.config['sensing']['adc'] == 'PT100_raspi_SMHAT':
+            sensor = sen.PT100_raspi_sequentmicrosystems_HAT()
 
         else:
             raise Exception(f'ADC "{self.config["sensing"]["adc"]}" not recognised/supported')

--- a/temperature_dc/code/measure.py
+++ b/temperature_dc/code/measure.py
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------------
 #
 #    Temperature Monitoring (Basic solution) -- This digital solution enables, measures,
-#    reports and records different  types of temperatures (ambient, process, equipment)
+#    reports and records different  types of temperatures (contact, air, radiated)
 #    so that the temperature conditions surrounding a process can be understood and 
-#    taken action upon. This version can work for 4 types of temperature sensors (now)
-#    which include k-type, RTD, ambient (AHT20), and NIR-based sensors. 
+#    taken action upon. Suppored sensors include 
+#    k-type thermocouples, RTDs, air samplers, and NIR-based sensors. 
 #    The solution provides a Grafana dashboard that 
 #    displays the temperature timeseries, set threshold value, and a state timeline showing 
 #    the chnage in temperature. An InfluxDB database is used to store timestamp, temperature, 
@@ -137,28 +137,37 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
 
             # Collect samples from ADC
             
-            if self.config['type']['type'] == 'processTemperature':
+            if self.config['type']['type'] == 'contactTemperature':
 
                 # Collect samples from ADC
                 try:
-                    sample = sensor.object_temp()
-                    # sample = sensor
-                    logger.info("Prorcess TemperatureMeasureBuildingBlock- STAGE-3 done")
+                    sample = sensor.contact_temp()
+                    logger.info("Contact TemperatureMeasureBuildingBlock- STAGE-3 done")
                     sample_accumulator += sample
                     num_samples+=1
                 except Exception as e:
                     logger.error(f"Sampling led to exception{e}")
-            elif self.config['type']['type'] == 'ambientTemperature':
+
+            elif self.config['type']['type'] == 'airTemperature':
                 try:
-                    sample = sensor.ambient_temp()
-                    # sample = sensor
-                    logger.info("Ambient TemperatureMeasureBuildingBlock- STAGE-3 done")
+                    sample = sensor.air_temp()
+                    logger.info("Air TemperatureMeasureBuildingBlock- STAGE-3 done")
                     sample_accumulator += sample
                     num_samples+=1
                 except Exception as e:
                     logger.error(f"Sampling led to exception{e}")
+
+            elif self.config['type']['type'] == 'radiativeTemperature':
+                try:
+                    sample = sensor.radiative_temp()
+                    logger.info("Air TemperatureMeasureBuildingBlock- STAGE-3 done")
+                    sample_accumulator += sample
+                    num_samples+=1
+                except Exception as e:
+                    logger.error(f"Sampling led to exception{e}")
+
             else:
-                logger.info("config ambient or process temperature first!")
+                logger.info("config temperature type first!")
 
             # handle timestamps and timezones
             if time.time() > next_check:

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -127,6 +127,16 @@ class PT100_raspi:
         self.MyMax.spi.close()
 
 
+class PT100_raspi_sequentmicrosystems_HAT:
+
+    def __init__(self):
+        import adc.SequentMicrosystemsRTDHAT as RTDHAT
+        self.RTD_ADC = RTDHAT
+
+    def ambient_temp(self):
+        return self.RTD_ADC.get_poly5(0, 6) # hard coding first layer, channel "RTD6". To be made configurable.
+
+
 class aht20:
     def __init__(self):
         import board

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -111,7 +111,7 @@ class PT100_raspi:
     def __init__(self):
         self.MyMax = MAX31865.max31865()
         self.MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
-        self. = MAX31865.PT_RTD(100)
+        self.MyRTD = MAX31865.PT_RTD(100)
 
     def ambient_temp(self):
         logger.into("TemperatureMeasureBuildingBlock- PT100_raspi started")

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -43,7 +43,7 @@ class k_type:
         self.max31855 = DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS)
 
 
-    def ambient_temp(self):
+    def contact_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- k-type started")
         return self.max31855.read_celsius()
 
@@ -55,11 +55,12 @@ class MLX90614_temp:
         self.bus = SMBus(1)
         self.sensor=MLX90614(self.bus,address=0x5a)
 
-    def ambient_temp(self):
+    def contact_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- MLX90614_temp started")
         return self.sensor.get_amb_temp()
 
-    def object_temp(self):
+    def radiative_temp(self):
+        logger.info("TemperatureMeasureBuildingBlock- MLX90614_temp started")
         return self.sensor.get_obj_temp()
 
 
@@ -71,7 +72,7 @@ class sht30:
         time.sleep(0.5)
         self.data = self.bus.read_i2c_block_data(0x44, 0x00, 6)
 
-    def ambient_temp(self):
+    def air_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- SHT30 started")
         self.temp = self.data[0] * 256 + self.data[1]
         return -45 + (175 * self.temp / 65535.0)
@@ -84,7 +85,7 @@ class W1Therm:
         self.sensor = W1ThermSensor()
 
 
-    def ambient_temp(self):
+    def contact_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- w1therm started")
         return self.sensor.get_temperature()
 
@@ -96,7 +97,7 @@ class PT100_arduino:
         import serial
         self.ser = serial.Serial(port='/dev/ttyACM0', baudrate=115200, timeout=1)
 
-    def ambient_temp(self):
+    def contact_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- PT100_arduino started")
         with self.ser as ser:
             if ser.isOpen():
@@ -119,7 +120,7 @@ class PT100_raspi:
         self.MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
         self.MyRTD = MAX31865.PT_RTD(100)
 
-    def ambient_temp(self):
+    def contact_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- PT100_raspi started")
         return self.MyRTD(self.MyMax())
 
@@ -133,7 +134,7 @@ class PT100_raspi_sequentmicrosystems_HAT:
         import adc.SequentMicrosystemsRTDHAT as RTDHAT
         self.RTD_ADC = RTDHAT
 
-    def ambient_temp(self):
+    def contact_temp(self):
         return self.RTD_ADC.get_poly5(0, 6) # hard coding first layer, channel "RTD6". To be made configurable.
 
 
@@ -146,6 +147,6 @@ class aht20:
         i2c = board.I2C()
         self.sensor = adafruit_ahtx0.AHTx0(i2c)
 
-    def ambient_temp(self):
+    def air_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- aht20 started")
         return self.sensor.temperature

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -1,15 +1,15 @@
 
-import math
+#import math                                # Not used currently
 from smbus2 import SMBus
-from mlx90614 import MLX90614
-from w1thermsensor import W1ThermSensor
-import max6675
-import MAX31865
-import adafruit_ahtx0
-import board
+#from mlx90614 import MLX90614              # imported below when class is created
+#from w1thermsensor import W1ThermSensor    # imported below when class is created
+#import max6675                             # Not used currently
+#import MAX31865                            # imported below when class is created
+#import adafruit_ahtx0                      # imported below when class is created
+#import board                               # imported below when class is created
 import logging
 import importlib
-import serial
+#import serial                              # imported below when class is created
 import json
 import time
 
@@ -20,12 +20,12 @@ import time
 logger = logging.getLogger("main.measure.sensor")
 
 
-adc_module = "DFRobot_MAX31855"
-try:
-    local_lib = importlib.import_module(f"adc.{adc_module}")
-    logger.debug(f"Imported {adc_module}")
-except ModuleNotFoundError as e:
-    logger.error(f"Unable to import module {adc_module}. Stopping!!")
+#adc_module = "DFRobot_MAX31855"
+#try:
+#    local_lib = importlib.import_module(f"adc.{adc_module}")
+#    logger.debug(f"Imported {adc_module}")
+#except ModuleNotFoundError as e:
+#    logger.error(f"Unable to import module {adc_module}. Stopping!!")
 
 
 
@@ -35,10 +35,12 @@ except ModuleNotFoundError as e:
 class k_type:
     # https://github.com/DFRobot/DFRobot_MAX31855/tree/main/raspberrypi/python
     def __init__(self):
+        import adc.DFRobot_MAX31855 as DFRobot_MAX31855
         self.I2C_1       = 0x01
         self.I2C_ADDRESS = 0x10
         #Create MAX31855 object
-        self.max31855 = local_lib.DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS)
+        #self.max31855 = local_lib.DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS)
+        self.max31855 = DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS)
 
 
     def ambient_temp(self):
@@ -49,6 +51,7 @@ class k_type:
 
 class MLX90614_temp:
     def __init__(self):
+        from mlx90614 import MLX90614
         self.bus = SMBus(1)
         self.sensor=MLX90614(self.bus,address=0x5a)
 
@@ -77,6 +80,7 @@ class sht30:
 
 class W1Therm:
     def __init__(self):
+        from w1thermsensor import W1ThermSensor
         self.sensor = W1ThermSensor()
 
 
@@ -89,6 +93,7 @@ class W1Therm:
 class PT100_arduino:
 
     def __init__(self):
+        import serial
         self.ser = serial.Serial(port='/dev/ttyACM0', baudrate=115200, timeout=1)
 
     def ambient_temp(self):
@@ -109,12 +114,13 @@ class PT100_arduino:
 class PT100_raspi:
 
     def __init__(self):
+        import adc.MAX31865 as MAX31865
         self.MyMax = MAX31865.max31865()
         self.MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
         self.MyRTD = MAX31865.PT_RTD(100)
 
     def ambient_temp(self):
-        logger.into("TemperatureMeasureBuildingBlock- PT100_raspi started")
+        logger.info("TemperatureMeasureBuildingBlock- PT100_raspi started")
         return self.MyRTD(self.MyMax())
 
     def close(self):
@@ -123,6 +129,8 @@ class PT100_raspi:
 
 class aht20:
     def __init__(self):
+        import board
+        import adafruit_ahtx0
         # self.bus = SMBus(1)
         # self.sensor=adafruit_ahtx0.AHTx0(self.bus,address=0x38)
         i2c = board.I2C()

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -109,16 +109,16 @@ class PT100_arduino:
 class PT100_raspi:
 
     def __init__(self):
-        MyMax = MAX31865.max31865()
-        MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
-        MyRTD = MAX31865.PT_RTD(100)
+        self.MyMax = MAX31865.max31865()
+        self.MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
+        self. = MAX31865.PT_RTD(100)
 
     def ambient_temp(self):
         logger.into("TemperatureMeasureBuildingBlock- PT100_raspi started")
-        return MyRTD(MyMax())
+        return self.MyRTD(self.MyMax())
 
     def close(self):
-        MyMax.spi.close()
+        self.MyMax.spi.close()
 
 
 class aht20:

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -110,7 +110,7 @@ class PT100_raspi:
 
     def __init__(self):
         MyMax = MAX31865.max31865()
-        MyMax.set_config(VBias=1, continous=1, filter=50Hz)
+        MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
         MyRTD = MAX31865.PT_RTD(100)
 
     def ambient_temp(self):

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -4,6 +4,7 @@ from smbus2 import SMBus
 from mlx90614 import MLX90614
 from w1thermsensor import W1ThermSensor
 import max6675
+import MAX31865
 import adafruit_ahtx0
 import board
 import logging
@@ -37,12 +38,12 @@ class k_type:
         self.I2C_1       = 0x01
         self.I2C_ADDRESS = 0x10
         #Create MAX31855 object
-        self.max31855 = local_lib.DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS) 
-        
+        self.max31855 = local_lib.DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS)
+
 
     def ambient_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- k-type started")
-        return self.max31855.read_celsius() 
+        return self.max31855.read_celsius()
 
 
 
@@ -57,7 +58,7 @@ class MLX90614_temp:
 
     def object_temp(self):
         return self.sensor.get_obj_temp()
-        
+
 
 
 class sht30:
@@ -77,7 +78,7 @@ class sht30:
 class W1Therm:
     def __init__(self):
         self.sensor = W1ThermSensor()
-        
+
 
     def ambient_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- w1therm started")
@@ -89,7 +90,7 @@ class PT100_arduino:
 
     def __init__(self):
         self.ser = serial.Serial(port='/dev/ttyACM0', baudrate=115200, timeout=1)
-    
+
     def ambient_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- PT100_arduino started")
         with self.ser as ser:
@@ -105,7 +106,19 @@ class PT100_arduino:
         self.ser.close()
 
 
+class PT100_raspi:
 
+    def __init__(self):
+        MyMax = MAX31865.max31865()
+        MyMax.set_config(VBias=1, continous=1, filter=50Hz)
+        MyRTD = MAX31865.PT_RTD(100)
+
+    def ambient_temp(self):
+        logger.into("TemperatureMeasureBuildingBlock- PT100_raspi started")
+        return MyRTD(MyMax())
+
+    def close(self):
+        MyMax.spi.close()
 
 
 class aht20:
@@ -114,7 +127,7 @@ class aht20:
         # self.sensor=adafruit_ahtx0.AHTx0(self.bus,address=0x38)
         i2c = board.I2C()
         self.sensor = adafruit_ahtx0.AHTx0(i2c)
-        
+
     def ambient_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- aht20 started")
         return self.sensor.temperature

--- a/temperature_dc/code/wrapper.py
+++ b/temperature_dc/code/wrapper.py
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------------
 #
 #    Temperature Monitoring (Basic solution) -- This digital solution enables, measures,
-#    reports and records different  types of temperatures (ambient, process, equipment)
+#    reports and records different  types of temperatures (contact, air, radiated)
 #    so that the temperature conditions surrounding a process can be understood and 
-#    taken action upon. This version can work for 4 types of temperature sensors (now)
-#    which include k-type, RTD, ambient (AHT20), and NIR-based sensors. 
+#    taken action upon. Suppored sensors include 
+#    k-type thermocouples, RTDs, air samplers, and NIR-based sensors.
 #    The solution provides a Grafana dashboard that 
 #    displays the temperature timeseries, set threshold value, and a state timeline showing the chnage in temperature.
 #    An InfluxDB database is used to store timestamp, temperature, threshold and status. 

--- a/temperature_dc/config/config.toml
+++ b/temperature_dc/config/config.toml
@@ -4,11 +4,11 @@
 [threshold]
     th1 = 50  #for 1 sensor
 
-
 [sensing]
     # uncomment the sensor that you are using (default is DS18B20)
-    adc = "W1ThermSensor"   # Always connect the DS18B20 sensor to GPIO4 or PIN 7 of the RPI4
+    #adc = "W1ThermSensor"   # Always connect the DS18B20 sensor to GPIO4 or PIN 7 of the RPI4
     #adc = "PT100_arduino"
+    adc = "PT100_raspi"
     #adc = "AHT20"
     #adc = "MLX90614_temp"
     #adc = "SHT30"
@@ -20,8 +20,6 @@
 [type]
     #type = "processTemperature"
     type = "ambientTemperature"
-
-
 
 [computing]
 	hardware="Pi4"

--- a/temperature_dc/config/config.toml
+++ b/temperature_dc/config/config.toml
@@ -8,7 +8,8 @@
     # uncomment the sensor that you are using (default is DS18B20)
     #adc = "W1ThermSensor"   # Always connect the DS18B20 sensor to GPIO4 or PIN 7 of the RPI4
     #adc = "PT100_arduino"
-    adc = "PT100_raspi"
+    #adc = "PT100_raspi"
+    adc = "PT100_raspi_SMHAT"
     #adc = "AHT20"
     #adc = "MLX90614_temp"
     #adc = "SHT30"

--- a/temperature_dc/config/config.toml
+++ b/temperature_dc/config/config.toml
@@ -19,8 +19,9 @@
     sample_interval = 1
 
 [type]
-    #type = "processTemperature"
-    type = "ambientTemperature"
+    type = "contactTemperature"
+    #type = "airTemperature"
+    #type = "radiativeTemperature"
 
 [computing]
 	hardware="Pi4"


### PR DESCRIPTION
Recategorises our temperature sensors. 

Moving away from language of 
"ambient", "process", "equipment" and "industrial"
towards
"contact", "air" and "radiated"
to better describe the operation of the sensors. See branch description for more details. 

Thermocouples, RTDs and on-die sensors are grouped into "contact". 

This PR also covers the branch hardware-support/PT100_raspi, adding support for both the MAX31865 and Sequent Microsystems RTD DAQ HAT. 