### PR TITLE
Feature/clean dashboard

### DIFF
--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -278,7 +278,7 @@
         },
         "mergeValues": true,
         "rowHeight": 0.9,
-        "showValue": "auto",
+        "showValue": "never",
         "tooltip": {
           "mode": "single",
           "sort": "none"
@@ -416,6 +416,6 @@
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 15,
+  "version": 4,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -115,7 +115,7 @@
           "refId": "A"
         }
       ],
-      "title": "Ambient temperature",
+      "title": "Temperature History",
       "type": "timeseries"
     },
     {
@@ -194,7 +194,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^temp \\{Threshold=\"50\", machine=\"Machine_1\", sensor=\"MLX90614_temp\"\\}$/",
+          "fields": "",
           "values": false
         },
         "textMode": "auto"
@@ -206,7 +206,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -294,7 +294,7 @@
           "refId": "A"
         }
       ],
-      "title": "Alert Timeline",
+      "title": "Alert History",
       "type": "state-timeline"
     },
     {
@@ -409,13 +409,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 7,
+  "version": 10,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -87,8 +87,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
+        "h": 8,
+        "w": 18,
         "x": 0,
         "y": 0
       },
@@ -111,7 +111,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |>filter(fn: (r) => r[\"Threshold\"] == \"${threshold}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],
@@ -179,22 +179,22 @@
         ]
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
+        "h": 8,
+        "w": 6,
+        "x": 18,
         "y": 0
       },
       "id": 6,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "vertical",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
+          "fields": "/^temp \\{Threshold=\"50\", machine=\"Machine_1\", sensor=\"MLX90614_temp\"\\}$/",
           "values": false
         },
         "textMode": "auto"
@@ -206,11 +206,11 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> filter(fn: (r) => r[\"Threshold\"] == \"${threshold}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
-      "title": "Alert Status & Temperature Value",
+      "title": "Temperature Value",
       "type": "stat"
     },
     {
@@ -266,7 +266,7 @@
         "h": 7,
         "w": 18,
         "x": 0,
-        "y": 9
+        "y": 8
       },
       "id": 8,
       "options": {
@@ -290,7 +290,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |>filter(fn: (r) => r[\"Threshold\"] == \"${threshold}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -348,12 +348,12 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 9
+        "y": 8
       },
       "id": 4,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -372,7 +372,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |>filter(fn: (r) => r[\"Threshold\"] == \"${threshold}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -405,25 +405,6 @@
         "query": "Machine_1",
         "skipUrlSync": false,
         "type": "textbox"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "50",
-          "value": "50"
-        },
-        "hide": 0,
-        "name": "threshold",
-        "options": [
-          {
-            "selected": true,
-            "text": "50",
-            "value": "50"
-          }
-        ],
-        "query": "50",
-        "skipUrlSync": false,
-        "type": "textbox"
       }
     ]
   },
@@ -435,6 +416,6 @@
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 3,
+  "version": 7,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -59,7 +59,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": 10000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -111,7 +111,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],
@@ -226,7 +226,7 @@
           "custom": {
             "fillOpacity": 70,
             "lineWidth": 0,
-            "spanNulls": false
+            "spanNulls": 10000
           },
           "mappings": [],
           "thresholds": {
@@ -274,7 +274,7 @@
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "mergeValues": true,
         "rowHeight": 0.9,
@@ -290,7 +290,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: true)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -416,6 +416,6 @@
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 10,
+  "version": 15,
   "weekStart": ""
 }

--- a/temperature_dc/code/adc/MAX31865.py
+++ b/temperature_dc/code/adc/MAX31865.py
@@ -1,0 +1,164 @@
+# toby_max31865.py
+# Toby Harris 2024 @ IfM Engage
+# Usage: see test section at end of file
+
+import spidev
+from math import sqrt
+import time
+
+class max31865:
+
+	# Register definitions
+	REG_CONFIG_READ = 0x00
+	REG_CONFIG_WRITE = 0x80
+	REG_RTD_READING = 0x01
+
+
+	def __init__(self, R_Ref=438, spi_bus=0, spi_cs=0, spi_speed=7629, spi_clock_polarity=1, spi_clock_phase=1):
+
+		self.R_Ref = R_Ref	# ADC full scale. Ideally around 4*R_0dC. Our board's resistor is marked 431 => 430 ohms, but measuring it suggests 438.
+
+		self.spi = spidev.SpiDev()
+		self.spi.open(spi_bus, spi_cs)
+		self.spi.max_speed_hz = spi_speed
+		self.spi.mode = (spi_clock_polarity << 1 | spi_clock_phase)	# 0b11 or else...
+
+
+	def __call__(self):
+		return self.calculate_resistance(self._read_adc())
+
+
+	def _read_regs(self, first_reg_addr,  nregs=8):
+		"""Read nregs consecutive registers, starting from first_reg_addr"""
+
+		"""
+		A note on the registers of the MAX31865:
+		00h = Config
+		01h = RTD MSBs
+		02h = RTD LSBs
+		03h = High Fault Threshold MSB
+		04h = High Fault Threshold LSB
+		05h = Low Fault Threshold MSB
+		06h = Low Fault Threshold LSB
+		07h = Fault Status
+		"""
+
+		resp = self.spi.xfer2([first_reg_addr] + [0]*nregs)[1:] # Ignore first byte as it was while the command was being clocked in
+		return resp
+
+
+	def _write_reg(self, reg_addr, data):
+		self.spi.writebytes([reg_addr, data])			# Can be temperamental and cause seg faults, but behaving today.
+#		self.spi.xfer2([reg_addr, data])			# More reliable, even when discarding the response.
+
+
+	def _bytes_to_15bit(self, MSBs_byte, LSBs_byte):
+		"""extract a 15bit int from two bytes, MSB justified"""
+		return ((MSBs_byte <<8 | LSBs_byte) >> 1)
+
+
+	def _read_adc(self):
+		"""clock data out of the adc and return as int"""
+		reading_bytes = self._read_regs(self.REG_RTD_READING, 2)
+		ADC_Code = self._bytes_to_15bit(reading_bytes[0], reading_bytes[1])
+		return ADC_Code
+
+
+
+	def set_config(self, VBias=0, continous=0, oneshot=0, threewire=0, faultdetect=0, faultclear=0, filter50Hz=0):
+		"""
+		Overwrite the config register:
+		---------------
+		bit 7: Vbias (1=ON, 0=OFF). Needs to be on in either mode to get new readings.
+		bit 6: Conversion Mode (1=Auto/Continous, 0=OFF/Manual)
+		bit 5: 1-shot (1=1-shot on, auto cleared)
+		bit 4: 3-wire select (1=3 wire config, 0=2 or 4 wire config)
+		bits 3-2: fault detection cycle (0=none, otherwise see data sheet)
+		bit 1: fault status clear (1=Clear any fault, auto cleared)
+		bit 0: 50/60 Hz filter select (1=50Hz, 0=60Hz)
+		"""
+
+		new_config_byte = (VBias << 7 | continous << 6 | oneshot << 5 | threewire << 4 | faultdetect << 2 | faultclear << 1 | filter50Hz)
+		self._write_reg(self.REG_CONFIG_WRITE, new_config_byte)
+
+
+	def oneshot(self):
+		"""Request a single reading without otherwise changing the config."""
+		current_config = self._read_regs(self.REG_CONFIG_READ, 1)[0]
+		new_config = (current_config  | 0b00100000)
+		self._write_reg(self.REG_CONFIG_WRITE, new_config)
+
+
+	def calculate_resistance(self, adc_code, adc_fullscale=32768):
+		"""Calculate the resistance of the RTD, with R_Ref as full scale """
+		R_RTD = self.R_Ref * adc_code / adc_fullscale
+		return R_RTD
+
+
+class PT_RTD:
+
+	def __init__(self, R_0dC, a=3.9083e-3, b=-5.775e-7, c_pos=0, c_neg=-4.18301e-12):
+
+		self.R_0dC = R_0dC	# The RTD resistance at 0 degrees C. Common standards are 100 and 1000.
+
+		# A great model of PT-RTD resistance vs temperature is the Callendar-Van Dusen equation:
+		# R_RTD = R_0dC * (1 + a*T + b*T**2 + c*(T-100)*T**3)
+		# Standard constants (IEC7751/SAMA) as default
+
+		self.a = a
+		self.b = b
+		self.c_pos = c_pos	# For temperatures above 0 degrees C
+		self.c_neg = c_neg	# For temperatures below 0 degrees C
+
+
+	def __call__(self, resistance):
+		"""shorthand for most common usage"""
+		return self.calculate_temperature_quadratic(resistance)
+
+
+	def calculate_temperature_linear(self, resistance):
+
+		# Linear approximation:
+		T_C_linear = ((resistance / self.R_0dC) - 1) / self.a
+		return T_C_linear
+
+	def calculate_temperature_quadratic(self, resistance):
+
+		# Quadratic approximation (unfortunately the constants do not follow convention):
+		# R_RTD / R_0dC = 1 + aT + bt^2
+		# T = (-a +- sqrt(a^2-4b(1-R_RTD/R_0dC))) / 2b
+		T_C_quadratic = ( -self.a + sqrt((self.a**2)-4*self.b*(1-(resistance/self.R_0dC))) )/(2*self.b)
+		return T_C_quadratic
+
+#	def calculate_temperature_quartic(self, resistance):
+		# Full Callendar-Van Dussen, improves on quad below 0dC.
+		# tbd
+
+
+# test
+if __name__ == '__main__':
+
+	MyMax = max31865()
+	MyMax.set_config(VBias=1, filter50Hz=1)
+	time.sleep(0.5)
+	MyRTD = PT_RTD(100)
+
+	# test in oneshot mode
+	print("oneshot mode:")
+	for i in range(5):
+		MyMax.oneshot()
+		time.sleep(0.1) # after activating oneshot measurement, conversion takes about 60ms until DATA_READY falls low (=ready). 100ms is safe margin.
+		print(MyRTD(MyMax()))
+		time.sleep(1)
+	time.sleep(1)
+
+	# test in continous mode
+	print("continous mode:")
+	MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
+	time.sleep(0.5)
+
+	for i in range(5):
+		print(MyRTD(MyMax()))
+		time.sleep(1)
+
+	MyMax.spi.close()

--- a/temperature_dc/code/adc/SequentMicrosystemsRTDHAT.py
+++ b/temperature_dc/code/adc/SequentMicrosystemsRTDHAT.py
@@ -1,0 +1,115 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2020 Sequent Microsystems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+#import smbus  # The only Shoestring edit to the sequent microsystems code: 
+import smbus2 as smbus # swapping out the above line for this one.
+import struct
+
+# bus = smbus.SMBus(1)    # 0 = /dev/i2c-0 (port I2C0), 1 = /dev/i2c-1 (port I2C1)
+
+DEVICE_ADDRESS = 0x40  # 7 bit address (will be left shifted to add the read write bit)
+
+RTD_TEMPERATURE_ADD = 0
+RTD_RESISTANCE_ADD = 59
+
+
+def get(stack, channel):
+    if stack < 0 or stack > 7:
+        raise ValueError('Invalid stack level')
+    if channel < 1 or channel > 8:
+        raise ValueError('Invalid channel number')
+    val = (-273.15)
+    bus = smbus.SMBus(1)
+    try:
+        buff = bus.read_i2c_block_data(DEVICE_ADDRESS + stack, RTD_TEMPERATURE_ADD + (4 * (channel - 1)), 4)
+        val = struct.unpack('f', bytearray(buff))
+    except Exception as e:
+        bus.close()
+        raise ValueError('Fail to communicate with the RTD card with message: \"' + str(e) + '\"')
+    bus.close()
+    return val[0]
+
+
+def getRes(stack, channel):
+    if stack < 0 or stack > 7:
+        raise ValueError('Invalid stack level')
+    if channel < 1 or channel > 8:
+        raise ValueError('Invalid channel number')
+    val = (-273.15)
+    bus = smbus.SMBus(1)
+    try:
+        buff = bus.read_i2c_block_data(DEVICE_ADDRESS + stack, RTD_RESISTANCE_ADD + (4 * (channel - 1)), 4)
+        val = struct.unpack('f', bytearray(buff))
+    except Exception as e:
+        bus.close()
+        raise ValueError('Fail to communicate with the RTD card with message: \"' + str(e) + '\"')
+    bus.close()
+    return val[0]
+
+
+def get_poly5(stack: int, channel: int) -> float:
+    """
+    Convert RTD reading to Temperature, using 5th order polynomial fit of Temperature as a function of Resistance.
+    This fit provides much improved accuracy through the temperature range of [-200C, 660C], particularly near the high
+    and low ranges, compared to the default linear fitting function baked into the Sequent RTD Data Acquisition
+    Stackable Card for Raspberry Pi.  The coefficients for this fit were developed in a project documented
+    in https://github.com/ewjax/max31865
+
+        temp_C = (c5 * res^5) + (c4 * res^4) + (c3 * res^3) + (c2 * res^2) + (c1 * res) + c0
+
+    :param stack: 0-7, which hat to read
+    :param channel: 1-8, which RTD to read on indicated hat
+    :return: temperature, in celcius
+    """
+
+    # coeffs for 5th order fit
+    c5 = -2.10678E-11
+    c4 = 2.27311E-08
+    c3 = -8.20888E-06
+    c2 = 2.38589E-03
+    c1 = 2.24745E+00
+    c0 = -2.42522E+02
+
+    # get RTD resistance
+    res = getRes(stack, channel)
+
+    # do the math
+    #   Rearrange a bit to make it friendlier (less expensive) to calculate
+    #   temp_C = res ( res ( res ( res ( res * c5 + c4) + c3) + c2) + c1) + c0
+    temp_C = res * c5 + c4
+
+    temp_C *= res
+    temp_C += c3
+
+    temp_C *= res
+    temp_C += c2
+
+    temp_C *= res
+    temp_C += c1
+
+    temp_C *= res
+    temp_C += c0
+
+    return temp_C

--- a/temperature_dc/code/measure.py
+++ b/temperature_dc/code/measure.py
@@ -118,6 +118,8 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
             sensor = sen.aht20()
         elif self.config['sensing']['adc'] == 'PT100_arduino':
             sensor = sen.PT100_arduino()
+        elif self.config['sensing']['adc'] == 'PT100_raspi':
+            sensor = sen.PT100_raspi()
 
         else:
             raise Exception(f'ADC "{self.config["sensing"]["adc"]}" not recognised/supported')

--- a/temperature_dc/code/measure.py
+++ b/temperature_dc/code/measure.py
@@ -120,6 +120,8 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
             sensor = sen.PT100_arduino()
         elif self.config['sensing']['adc'] == 'PT100_raspi':
             sensor = sen.PT100_raspi()
+        elif self.config['sensing']['adc'] == 'PT100_raspi_SMHAT':
+            sensor = sen.PT100_raspi_sequentmicrosystems_HAT()
 
         else:
             raise Exception(f'ADC "{self.config["sensing"]["adc"]}" not recognised/supported')

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -127,6 +127,16 @@ class PT100_raspi:
         self.MyMax.spi.close()
 
 
+class PT100_raspi_sequentmicrosystems_HAT:
+
+    def __init__(self):
+        import adc.SequentMicrosystemsRTDHAT as RTDHAT
+        self.RTD_ADC = RTDHAT
+
+    def ambient_temp(self):
+        return self.RTD_ADC.get_poly5(0, 6) # hard coding first layer, channel "RTD6". To be made configurable.
+
+
 class aht20:
     def __init__(self):
         import board

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -111,7 +111,7 @@ class PT100_raspi:
     def __init__(self):
         self.MyMax = MAX31865.max31865()
         self.MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
-        self. = MAX31865.PT_RTD(100)
+        self.MyRTD = MAX31865.PT_RTD(100)
 
     def ambient_temp(self):
         logger.into("TemperatureMeasureBuildingBlock- PT100_raspi started")

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -1,15 +1,15 @@
 
-import math
+#import math                                # Not used currently
 from smbus2 import SMBus
-from mlx90614 import MLX90614
-from w1thermsensor import W1ThermSensor
-import max6675
-import MAX31865
-import adafruit_ahtx0
-import board
+#from mlx90614 import MLX90614              # imported below when class is created
+#from w1thermsensor import W1ThermSensor    # imported below when class is created
+#import max6675                             # Not used currently
+#import MAX31865                            # imported below when class is created
+#import adafruit_ahtx0                      # imported below when class is created
+#import board                               # imported below when class is created
 import logging
 import importlib
-import serial
+#import serial                              # imported below when class is created
 import json
 import time
 
@@ -20,12 +20,12 @@ import time
 logger = logging.getLogger("main.measure.sensor")
 
 
-adc_module = "DFRobot_MAX31855"
-try:
-    local_lib = importlib.import_module(f"adc.{adc_module}")
-    logger.debug(f"Imported {adc_module}")
-except ModuleNotFoundError as e:
-    logger.error(f"Unable to import module {adc_module}. Stopping!!")
+#adc_module = "DFRobot_MAX31855"
+#try:
+#    local_lib = importlib.import_module(f"adc.{adc_module}")
+#    logger.debug(f"Imported {adc_module}")
+#except ModuleNotFoundError as e:
+#    logger.error(f"Unable to import module {adc_module}. Stopping!!")
 
 
 
@@ -35,10 +35,12 @@ except ModuleNotFoundError as e:
 class k_type:
     # https://github.com/DFRobot/DFRobot_MAX31855/tree/main/raspberrypi/python
     def __init__(self):
+        import adc.DFRobot_MAX31855 as DFRobot_MAX31855
         self.I2C_1       = 0x01
         self.I2C_ADDRESS = 0x10
         #Create MAX31855 object
-        self.max31855 = local_lib.DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS)
+        #self.max31855 = local_lib.DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS)
+        self.max31855 = DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS)
 
 
     def ambient_temp(self):
@@ -49,6 +51,7 @@ class k_type:
 
 class MLX90614_temp:
     def __init__(self):
+        from mlx90614 import MLX90614
         self.bus = SMBus(1)
         self.sensor=MLX90614(self.bus,address=0x5a)
 
@@ -77,6 +80,7 @@ class sht30:
 
 class W1Therm:
     def __init__(self):
+        from w1thermsensor import W1ThermSensor
         self.sensor = W1ThermSensor()
 
 
@@ -89,6 +93,7 @@ class W1Therm:
 class PT100_arduino:
 
     def __init__(self):
+        import serial
         self.ser = serial.Serial(port='/dev/ttyACM0', baudrate=115200, timeout=1)
 
     def ambient_temp(self):
@@ -109,12 +114,13 @@ class PT100_arduino:
 class PT100_raspi:
 
     def __init__(self):
+        import adc.MAX31865 as MAX31865
         self.MyMax = MAX31865.max31865()
         self.MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
         self.MyRTD = MAX31865.PT_RTD(100)
 
     def ambient_temp(self):
-        logger.into("TemperatureMeasureBuildingBlock- PT100_raspi started")
+        logger.info("TemperatureMeasureBuildingBlock- PT100_raspi started")
         return self.MyRTD(self.MyMax())
 
     def close(self):
@@ -123,6 +129,8 @@ class PT100_raspi:
 
 class aht20:
     def __init__(self):
+        import board
+        import adafruit_ahtx0
         # self.bus = SMBus(1)
         # self.sensor=adafruit_ahtx0.AHTx0(self.bus,address=0x38)
         i2c = board.I2C()

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -109,16 +109,16 @@ class PT100_arduino:
 class PT100_raspi:
 
     def __init__(self):
-        MyMax = MAX31865.max31865()
-        MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
-        MyRTD = MAX31865.PT_RTD(100)
+        self.MyMax = MAX31865.max31865()
+        self.MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
+        self. = MAX31865.PT_RTD(100)
 
     def ambient_temp(self):
         logger.into("TemperatureMeasureBuildingBlock- PT100_raspi started")
-        return MyRTD(MyMax())
+        return self.MyRTD(self.MyMax())
 
     def close(self):
-        MyMax.spi.close()
+        self.MyMax.spi.close()
 
 
 class aht20:

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -110,7 +110,7 @@ class PT100_raspi:
 
     def __init__(self):
         MyMax = MAX31865.max31865()
-        MyMax.set_config(VBias=1, continous=1, filter=50Hz)
+        MyMax.set_config(VBias=1, continous=1, filter50Hz=1)
         MyRTD = MAX31865.PT_RTD(100)
 
     def ambient_temp(self):

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -4,6 +4,7 @@ from smbus2 import SMBus
 from mlx90614 import MLX90614
 from w1thermsensor import W1ThermSensor
 import max6675
+import MAX31865
 import adafruit_ahtx0
 import board
 import logging
@@ -37,12 +38,12 @@ class k_type:
         self.I2C_1       = 0x01
         self.I2C_ADDRESS = 0x10
         #Create MAX31855 object
-        self.max31855 = local_lib.DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS) 
-        
+        self.max31855 = local_lib.DFRobot_MAX31855(self.I2C_1 ,self.I2C_ADDRESS)
+
 
     def ambient_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- k-type started")
-        return self.max31855.read_celsius() 
+        return self.max31855.read_celsius()
 
 
 
@@ -57,7 +58,7 @@ class MLX90614_temp:
 
     def object_temp(self):
         return self.sensor.get_obj_temp()
-        
+
 
 
 class sht30:
@@ -77,7 +78,7 @@ class sht30:
 class W1Therm:
     def __init__(self):
         self.sensor = W1ThermSensor()
-        
+
 
     def ambient_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- w1therm started")
@@ -89,7 +90,7 @@ class PT100_arduino:
 
     def __init__(self):
         self.ser = serial.Serial(port='/dev/ttyACM0', baudrate=115200, timeout=1)
-    
+
     def ambient_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- PT100_arduino started")
         with self.ser as ser:
@@ -105,7 +106,19 @@ class PT100_arduino:
         self.ser.close()
 
 
+class PT100_raspi:
 
+    def __init__(self):
+        MyMax = MAX31865.max31865()
+        MyMax.set_config(VBias=1, continous=1, filter=50Hz)
+        MyRTD = MAX31865.PT_RTD(100)
+
+    def ambient_temp(self):
+        logger.into("TemperatureMeasureBuildingBlock- PT100_raspi started")
+        return MyRTD(MyMax())
+
+    def close(self):
+        MyMax.spi.close()
 
 
 class aht20:
@@ -114,7 +127,7 @@ class aht20:
         # self.sensor=adafruit_ahtx0.AHTx0(self.bus,address=0x38)
         i2c = board.I2C()
         self.sensor = adafruit_ahtx0.AHTx0(i2c)
-        
+
     def ambient_temp(self):
         logger.info("TemperatureMeasureBuildingBlock- aht20 started")
         return self.sensor.temperature

--- a/temperature_dc/config/config.toml
+++ b/temperature_dc/config/config.toml
@@ -4,11 +4,11 @@
 [threshold]
     th1 = 50  #for 1 sensor
 
-
 [sensing]
     # uncomment the sensor that you are using (default is DS18B20)
-    adc = "W1ThermSensor"   # Always connect the DS18B20 sensor to GPIO4 or PIN 7 of the RPI4
+    #adc = "W1ThermSensor"   # Always connect the DS18B20 sensor to GPIO4 or PIN 7 of the RPI4
     #adc = "PT100_arduino"
+    adc = "PT100_raspi"
     #adc = "AHT20"
     #adc = "MLX90614_temp"
     #adc = "SHT30"
@@ -20,8 +20,6 @@
 [type]
     #type = "processTemperature"
     type = "ambientTemperature"
-
-
 
 [computing]
 	hardware="Pi4"

--- a/temperature_dc/config/config.toml
+++ b/temperature_dc/config/config.toml
@@ -8,7 +8,8 @@
     # uncomment the sensor that you are using (default is DS18B20)
     #adc = "W1ThermSensor"   # Always connect the DS18B20 sensor to GPIO4 or PIN 7 of the RPI4
     #adc = "PT100_arduino"
-    adc = "PT100_raspi"
+    #adc = "PT100_raspi"
+    adc = "PT100_raspi_SMHAT"
     #adc = "AHT20"
     #adc = "MLX90614_temp"
     #adc = "SHT30"


### PR DESCRIPTION
Simplify the dashboard by removing a lot of duplicate data. 

Before:
![unclean_dash](https://github.com/DigitalShoestringSolutions/TemperatureMonitoringStarterSolution/assets/51968582/f997d47e-3e5f-4029-91c9-59f0c249e99e)

After: 
![clean_dash](https://github.com/DigitalShoestringSolutions/TemperatureMonitoringStarterSolution/assets/51968582/39389724-68bf-4263-a98d-40be2f983a70)


There is no gain from displaying the alert value twice, or having the same plot shown behind the values as well as beside them. 
The threshold global variable editor has been removed, as the only thing it can be used for is breaking the data pipeline. 

Tested with multiple contact sensors. 
In the case of merge conflicts between this and my other PR (type naming), keep only the dashboard from this. 