### PR TITLE
Feature/simple dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
 # Temperature Monitoring Starter Solution
-Run with docker: `docker compose up --build`

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -59,7 +59,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": 10000,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -87,8 +87,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
+        "h": 8,
+        "w": 18,
         "x": 0,
         "y": 0
       },
@@ -111,11 +111,11 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |>filter(fn: (r) => r[\"Threshold\"] == \"${threshold}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\n  |> yield(name: \"mean\")",
           "refId": "A"
         }
       ],
-      "title": "Ambient temperature",
+      "title": "Temperature History",
       "type": "timeseries"
     },
     {
@@ -179,15 +179,15 @@
         ]
       },
       "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
+        "h": 8,
+        "w": 6,
+        "x": 18,
         "y": 0
       },
       "id": 6,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "vertical",
         "reduceOptions": {
@@ -206,11 +206,11 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> filter(fn: (r) => r[\"Threshold\"] == \"${threshold}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
-      "title": "Alert Status & Temperature Value",
+      "title": "Temperature Value",
       "type": "stat"
     },
     {
@@ -226,7 +226,7 @@
           "custom": {
             "fillOpacity": 70,
             "lineWidth": 0,
-            "spanNulls": false
+            "spanNulls": 10000
           },
           "mappings": [],
           "thresholds": {
@@ -266,7 +266,7 @@
         "h": 7,
         "w": 18,
         "x": 0,
-        "y": 9
+        "y": 8
       },
       "id": 8,
       "options": {
@@ -274,11 +274,11 @@
         "legend": {
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "mergeValues": true,
         "rowHeight": 0.9,
-        "showValue": "auto",
+        "showValue": "never",
         "tooltip": {
           "mode": "single",
           "sort": "none"
@@ -290,11 +290,11 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |>filter(fn: (r) => r[\"Threshold\"] == \"${threshold}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: true)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
-      "title": "Alert Timeline",
+      "title": "Alert History",
       "type": "state-timeline"
     },
     {
@@ -348,12 +348,12 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 9
+        "y": 8
       },
       "id": 4,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -372,7 +372,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |>filter(fn: (r) => r[\"Threshold\"] == \"${threshold}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -405,36 +405,17 @@
         "query": "Machine_1",
         "skipUrlSync": false,
         "type": "textbox"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "50",
-          "value": "50"
-        },
-        "hide": 0,
-        "name": "threshold",
-        "options": [
-          {
-            "selected": true,
-            "text": "50",
-            "value": "50"
-          }
-        ],
-        "query": "50",
-        "skipUrlSync": false,
-        "type": "textbox"
       }
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -87,7 +87,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 15,
         "w": 18,
         "x": 0,
         "y": 0
@@ -179,7 +179,7 @@
         ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 15,
         "w": 6,
         "x": 18,
         "y": 0
@@ -266,7 +266,7 @@
         "h": 7,
         "w": 18,
         "x": 0,
-        "y": 8
+        "y": 15
       },
       "id": 8,
       "options": {
@@ -348,7 +348,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 8
+        "y": 15
       },
       "id": 4,
       "options": {
@@ -416,6 +416,6 @@
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 4,
+  "version": 2,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -87,7 +87,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 15,
+        "h": 9,
         "w": 18,
         "x": 0,
         "y": 0
@@ -179,7 +179,7 @@
         ]
       },
       "gridPos": {
-        "h": 15,
+        "h": 9,
         "w": 6,
         "x": 18,
         "y": 0
@@ -266,7 +266,7 @@
         "h": 7,
         "w": 18,
         "x": 0,
-        "y": 15
+        "y": 9
       },
       "id": 8,
       "options": {
@@ -348,7 +348,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 15
+        "y": 9
       },
       "id": 4,
       "options": {
@@ -416,6 +416,6 @@
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 2,
+  "version": 6,
   "weekStart": ""
 }


### PR DESCRIPTION
Simplify the dashboard by removing a lot of duplicate data. 

Before:
![unclean_dash](https://github.com/DigitalShoestringSolutions/TemperatureMonitoringStarterSolution/assets/51968582/f997d47e-3e5f-4029-91c9-59f0c249e99e)

After: 
![clean_dash](https://github.com/DigitalShoestringSolutions/TemperatureMonitoringStarterSolution/assets/51968582/39389724-68bf-4263-a98d-40be2f983a70)


There is no gain from displaying the alert value twice, or having the same plot shown behind the values as well as beside them. 
The threshold global variable editor has been removed, as the only thing it can be used for is breaking the data pipeline. 